### PR TITLE
 Add GetModuleDisplayNameMethod to API

### DIFF
--- a/Assets/Scripts/API/APIProperties.cs
+++ b/Assets/Scripts/API/APIProperties.cs
@@ -88,7 +88,7 @@ public class APIProperties : MonoBehaviour, IDictionary<string, object>
     {
         get
         {
-            throw new NotImplementedException("The Values property is not supported in this Dictionary.");
+            throw new NotSupportedException("The Values property is not supported in this Dictionary.");
         }
     }
 
@@ -117,22 +117,22 @@ public class APIProperties : MonoBehaviour, IDictionary<string, object>
 
     public void Add(string key, object value)
     {
-        throw new NotImplementedException("You can't add items to this Dictionary.");
+        throw new NotSupportedException("You can't add items to this Dictionary.");
     }
 
     public void Add(KeyValuePair<string, object> item)
     {
-        throw new NotImplementedException("You can't add items to this Dictionary.");
+        throw new NotSupportedException("You can't add items to this Dictionary.");
     }
 
     public void Clear()
     {
-        throw new NotImplementedException("You can't clear this Dictionary.");
+        throw new NotSupportedException("You can't clear this Dictionary.");
     }
 
     public bool Contains(KeyValuePair<string, object> item)
     {
-        throw new NotImplementedException("The Contains method is not supported in this Dictionary.");
+        throw new NotSupportedException("The Contains method is not supported in this Dictionary.");
     }
 
     public bool ContainsKey(string key)
@@ -142,22 +142,22 @@ public class APIProperties : MonoBehaviour, IDictionary<string, object>
 
     public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
     {
-        throw new NotImplementedException("The CopyTo method is not supported in this Dictionary.");
+        throw new NotSupportedException("The CopyTo method is not supported in this Dictionary.");
     }
 
     public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
     {
-        throw new NotImplementedException("The GetEnumerator method is not supported in this Dictionary.");
+        throw new NotSupportedException("The GetEnumerator method is not supported in this Dictionary.");
     }
 
     public bool Remove(KeyValuePair<string, object> item)
     {
-        throw new NotImplementedException("The Remove method is not supported in this Dictionary.");
+        throw new NotSupportedException("The Remove method is not supported in this Dictionary.");
     }
 
     public bool Remove(string key)
     {
-        throw new NotImplementedException("The Remove method is not supported in this Dictionary.");
+        throw new NotSupportedException("The Remove method is not supported in this Dictionary.");
     }
 
     public bool TryGetValue(string key, out object value)
@@ -176,6 +176,6 @@ public class APIProperties : MonoBehaviour, IDictionary<string, object>
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        throw new NotImplementedException("The GetEnumerator method is not supported in this Dictionary.");
+        throw new NotSupportedException("The GetEnumerator method is not supported in this Dictionary.");
     }
 }

--- a/Assets/Scripts/ModSelectorService.cs
+++ b/Assets/Scripts/ModSelectorService.cs
@@ -287,7 +287,7 @@ public class ModSelectorService : MonoBehaviour
 
     public enum ModType
     {
-        [Description("Solvable Modules")] 
+        [Description("Solvable Modules")]
         SolvableModule,
 
         [Description("Needy Modules")]
@@ -337,6 +337,8 @@ public class ModSelectorService : MonoBehaviour
         _properties.Add("AllWidgets", () => GetModNames(ModType.Widget), null);
         _properties.Add("AllGameplayRooms", () => GetModNames(ModType.GameplayRoom), null);
         _properties.Add("AllServices", () => GetModNames(ModType.Service), null);
+
+        _properties.Add("GetModuleDisplayNameMethod", () => (Func<string, string>)GetModuleDisplayName, null);
 
         _properties.Add("DisabledMods", () => ProfileManager.ActiveDisableSet, null);
         _properties.Add("DisabledSolvableModules", () => ProfileManager.GetActiveDisableList(ModType.SolvableModule), null);
@@ -645,6 +647,21 @@ public class ModSelectorService : MonoBehaviour
             .Concat(GetModNamesAndDisplayNames(ModType.Service));
     }
 
+    public string GetModuleDisplayName(string moduleType)
+    {
+        SolvableModule solvableModule;
+        if (_allSolvableModules.TryGetValue(moduleType, out solvableModule))
+        {
+            return solvableModule.ModuleName;
+        }
+        NeedyModule needyModule;
+        if (_allNeedyModules.TryGetValue(moduleType, out needyModule))
+        {
+            return needyModule.ModuleName;
+        }
+        return null;
+    }
+
     public void EnableAll()
     {
         EnableAllModules();
@@ -756,7 +773,7 @@ public class ModSelectorService : MonoBehaviour
             modWrapper.EnableModObjects(modType);
         }
     }
-    
+
     public void DisableAllMods(Type modType)
     {
         foreach (ModWrapper modWrapper in _allMods.Values)

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.1.0p4
+m_EditorVersion: 2017.4.36f1


### PR DESCRIPTION
This branch adds a method to the API allowing other mods to get display names of bomb modules, including disabled ones.
An example of a mod that could make use of this is Dynamic Mission Generator.
```CSharp
var modSelectorApi = GameObject.Find("ModSelector_Info").GetComponent<IDictionary<string, object>>();
GetModuleDisplayName = (Func<string, string>) modSelectorApi["GetModuleDisplayNameMethod"];
var name = GetModuleDisplayName(moduleID);
```