### PR TITLE
Address API bug

### DIFF
--- a/Assets/Scripts/ProfileManager.cs
+++ b/Assets/Scripts/ProfileManager.cs
@@ -264,12 +264,12 @@ public static class ProfileManager
                 }
             }
 
-            UpdateProfileSelection();
         }
         catch (Exception ex)
         {
             Debug.LogException(ex);
         }
+        UpdateProfileSelection();
     }
 
     public static void SaveActiveConfiguration()


### PR DESCRIPTION
When attempting to use the Mod Selector API through another mod, and ModSelectorConfig.json is not present in %APPDATA%\..\LocalLow\Keep Talking and Nobody Explodes\, the FileNotFoundException in ReloadActiveConfiguration() causes the method UpdateProfileSelection() to never get called, and the mod lists are thus null until something calls that method.
Seeing as many things in Mod Selector call this method and it doesn't appear to cause any issues, I have moved the UpdateProfileSelection method outside of the try/catch that the FileNotFoundException breaks out of.