### PR TITLE
Make ModSelector available in the gameplay room so other mods can add pages specific to it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ sysinfo.txt
 \.vs/config/applicationhost\.config
 
 .vs/
+.idea/

--- a/Assets/Editor/Resources/ModConfig.asset
+++ b/Assets/Editor/Resources/ModConfig.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: ModSelector
   title: Mod Selector
+  author: Bashly
   description: "[h1]Info[/h1]\r\nThis mod adds some additional UI to allow dynamic
     selection/veto of all loaded mods. Deselecting mods will make them unavailable
     in Free Play mode and any missions that would normally require them.\r\n\r\nThis
@@ -36,6 +37,6 @@ MonoBehaviour:
     mods installed.\r\nAs of v2.0.0, the Mod Selector is now a world-space object,
     much like the bomb binder, with dynamic profile merging and 2 modes of merging.\nAs
     of v2.5.0, Expert-style profiles work based on a EnableList rather than the DisableList."
-  version: v2.6.1
+  version: v2.7.1
   outputFolder: E:\Games\SteamLibrary\steamapps\common\Keep Talking and Nobody Explodes\mods
   previewImage: {fileID: 2800000, guid: 3635e2c54a9c5ee4e9896ba11c4f5a43, type: 3}

--- a/Assets/Editor/Scripts/AssetBundler.cs
+++ b/Assets/Editor/Scripts/AssetBundler.cs
@@ -1,10 +1,10 @@
-﻿using UnityEngine;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using UnityEditor;
 using System.Linq;
-using System;
 using System.Reflection;
+using UnityEditor;
+using UnityEngine;
 
 /// <summary>
 /// 
@@ -29,7 +29,7 @@ public class AssetBundler
     /// <summary>
     /// List of managed assemblies to ignore in the build (because they already exist in KTaNE itself)
     /// </summary>
-    static List<string> EXCLUDED_ASSEMBLIES = new List<string> { "KMFramework.dll" };
+    static List<string> EXCLUDED_ASSEMBLIES = new List<string> { "KMFramework.dll", "0Harmony.dll" };
 
     /// <summary>
     /// Location of MSBuild.exe tool
@@ -62,6 +62,11 @@ public class AssetBundler
     /// List of MonoScripts modified during the bundling process that need to be restored after.
     /// </summary>
     private List<string> scriptPathsToRestore = new List<string>();
+    
+    /// <summary>
+    /// A variable for holding the current BuildTarget, for Mac compatibility.
+    /// </summary>
+    BuildTarget target = BuildTarget.StandaloneWindows;
     #endregion
 
     [MenuItem("Keep Talking ModKit/Build AssetBundle _F6", priority = 10)]
@@ -92,6 +97,7 @@ public class AssetBundler
 
         bundler.assemblyName = ModConfig.ID;
         bundler.outputFolder = ModConfig.OutputFolder + "/" + bundler.assemblyName;
+        if (Application.platform == RuntimePlatform.OSXEditor) bundler.target = BuildTarget.StandaloneOSX;
 
         bool success = false;
 
@@ -110,6 +116,8 @@ public class AssetBundler
             //Update material info components for future compatibility checks
             bundler.UpdateMaterialInfo();
 
+			bool UseHarmony = false;
+
             //Build the assembly using either MSBuild or Unity EditorUtility methods
             if (useMSBuild)
             {
@@ -121,10 +129,10 @@ public class AssetBundler
             }
 
             //Copy any other non-Editor managed assemblies to the output folder
-            bundler.CopyManagedAssemblies();
+            bundler.CopyManagedAssemblies(ref UseHarmony);
 
             //Create the modInfo.json file and copy the preview image if available
-            bundler.CreateModInfo();
+            bundler.CreateModInfo(UseHarmony);
 
             //Copy the modSettings.json file from Assets into the build
             bundler.CopyModSettings();
@@ -238,20 +246,7 @@ public class AssetBundler
             .Select(path => "Assets/Plugins/Managed/" + Path.GetFileNameWithoutExtension(path))
             .ToList();
 
-        string unityAssembliesLocation;
-        switch (System.Environment.OSVersion.Platform)
-        {
-            case PlatformID.MacOSX:
-            case PlatformID.Unix:
-                unityAssembliesLocation = EditorApplication.applicationPath.Replace("Unity.app", "Unity.app/Contents/Managed/");
-                break;
-            case PlatformID.Win32NT:
-            default:
-                unityAssembliesLocation = EditorApplication.applicationPath.Replace("Unity.exe", "Data/Managed/");
-                break;
-        }
-
-        managedReferences.Add(unityAssembliesLocation + "UnityEngine");
+        managedReferences.Add(Path.Combine(EditorApplication.applicationContentsPath, "Managed/UnityEngine"));
 
         //Next we need to grab some type references and use reflection to build things the way Unity does.
         //Note that EditorUtility.CompileCSharp will do *almost* exactly the same thing, but it unfortunately
@@ -265,7 +260,7 @@ public class AssetBundler
         int apiCompatibilityLevel = 1; //NET_2_0 compatibility level is enum value 1
         Assembly assembly = Assembly.GetAssembly(typeof(MonoScript));
         var monoIslandType = assembly.GetType("UnityEditor.Scripting.MonoIsland");
-        object monoIsland = Activator.CreateInstance(monoIslandType, BuildTarget.StandaloneWindows, apiCompatibilityLevel, scriptArray, referenceArray, defineArray, outputFilename);
+        object monoIsland = Activator.CreateInstance(monoIslandType, target, apiCompatibilityLevel, scriptArray, referenceArray, defineArray, outputFilename);
 
         //MonoCompiler itself
         var monoCompilerType = assembly.GetType("UnityEditor.Scripting.Compilers.MonoCSharpCompiler");
@@ -379,18 +374,20 @@ public class AssetBundler
     /// <summary>
     /// Copy all managed non-Editor assemblies to the OUTPUT_FOLDER for inclusion alongside the mod bundle.
     /// </summary>
-    protected void CopyManagedAssemblies()
+    protected void CopyManagedAssemblies(ref bool UseHarmony)
     {
         IEnumerable<string> assetPaths = AssetDatabase.GetAllAssetPaths().Where(path => path.EndsWith(".dll") && path.StartsWith("Assets/Plugins"));
 
         //Now find any other managed plugins that should be included, other than the EXCLUDED_ASSEMBLIES list
         foreach (string assetPath in assetPaths)
-        {
+        {	
             var pluginImporter = AssetImporter.GetAtPath(assetPath) as PluginImporter;
 
             if (pluginImporter != null && !pluginImporter.isNativePlugin && pluginImporter.GetCompatibleWithAnyPlatform())
             {
                 string assetName = Path.GetFileName(assetPath);
+                if(assetName == "0Harmony.dll")
+					UseHarmony = true;
                 if (!EXCLUDED_ASSEMBLIES.Contains(assetName))
                 {
                     string dest = Path.Combine(outputFolder, Path.GetFileName(assetPath));
@@ -423,7 +420,7 @@ public class AssetBundler
         BuildPipeline.BuildAssetBundles(
             TEMP_BUILD_FOLDER, 
             BuildAssetBundleOptions.DeterministicAssetBundle | BuildAssetBundleOptions.CollectDependencies, 
-            BuildTarget.StandaloneWindows);
+            target);
 #pragma warning restore 618
 
         //We are only interested in the BUNDLE_FILENAME bundle (and not the extra AssetBundle or the manifest files
@@ -436,14 +433,28 @@ public class AssetBundler
     /// <summary>
     /// Creates a modInfo.json file and puts it in the OUTPUT_FOLDER.
     /// </summary>
-    protected void CreateModInfo()
+    protected void CreateModInfo(bool UseHarmony)
     {
-        File.WriteAllText(outputFolder + "/modInfo.json", ModConfig.Instance.ToJson());
+        File.WriteAllText(outputFolder + (UseHarmony ? "/modInfo_Harmony.json" : "/modInfo.json"), ModConfig.Instance.ToJson());
 
         if(ModConfig.PreviewImage != null)
         {
-            byte[] bytes = ModConfig.PreviewImage.EncodeToPNG();
-            File.WriteAllBytes(outputFolder + "/previewImage.png", bytes);
+            string previewImageAssetPath = AssetDatabase.GetAssetPath(ModConfig.PreviewImage);
+
+            if (!string.IsNullOrEmpty(previewImageAssetPath))
+            {
+                TextureImporter importer = AssetImporter.GetAtPath(previewImageAssetPath) as TextureImporter;
+
+                if (!importer.isReadable || importer.textureCompression != TextureImporterCompression.Uncompressed)
+                {
+                    importer.isReadable = true;
+                    importer.textureCompression = TextureImporterCompression.Uncompressed;
+                    importer.SaveAndReimport();
+                }
+
+                byte[] bytes = ModConfig.PreviewImage.EncodeToPNG();
+                File.WriteAllBytes(outputFolder + "/previewImage.png", bytes);
+            }
         }
     }
 
@@ -621,10 +632,16 @@ public class AssetBundler
                     {
                         if (material == null)
                         {
-                            Debug.LogWarning(string.Format("Renderer {0} has an empty material entry!", renderer.name));
+                            var obj = renderer.transform;
+                            var str = new List<string>();
+                            while (obj != null)
+                            {
+                                str.Add(obj.gameObject.name);
+                                obj = obj.parent;
+                            }
+                            Debug.LogWarningFormat("There is an unassigned material on the following object: {0}", string.Join(" > ", str.ToArray()));
                             continue;
                         }
-
                         materialInfo.ShaderNames.Add(material.shader.name);
 
                         if(material.shader.name == "Standard")

--- a/Assets/Editor/Scripts/Missions/KMMissionEditor.cs
+++ b/Assets/Editor/Scripts/Missions/KMMissionEditor.cs
@@ -21,11 +21,19 @@ public class KMMissionEditor : Editor
 
             //Basic mission meta-data
             EditorGUILayout.BeginHorizontal();
-            EditorGUILayout.PrefixLabel("ID:");
+            EditorGUILayout.PrefixLabel("ID");
             EditorGUILayout.SelectableLabel(serializedObject.targetObject.name);
             EditorGUILayout.EndHorizontal();
 
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("DisplayName"));
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.PrefixLabel("ID In-Game");
+            EditorGUILayout.SelectableLabel(string.Format("mod_{0}_{1}", ModConfig.ID, serializedObject.targetObject.name));
+            EditorGUILayout.EndHorizontal();
+
+            var displayNameProperty = serializedObject.FindProperty("DisplayName");
+            EditorGUILayout.PropertyField(displayNameProperty);
+            displayNameProperty.stringValue = displayNameProperty.stringValue.Trim();
+
             EditorGUILayout.PropertyField(serializedObject.FindProperty("Description"));
             EditorGUILayout.PropertyField(serializedObject.FindProperty("PacingEventsEnabled"));
 
@@ -142,10 +150,8 @@ public class KMMissionEditor : Editor
         EditorGUILayout.BeginHorizontal();
 
         //Count
-        componentPoolProperty.FindPropertyRelative("Count").intValue = EditorGUILayout.IntPopup(
-            componentPoolProperty.FindPropertyRelative("Count").intValue,
-            new string[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11" },
-            new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 }, GUILayout.Width(60));
+        componentPoolProperty.FindPropertyRelative("Count").intValue = Math.Max(EditorGUILayout.IntField(
+            componentPoolProperty.FindPropertyRelative("Count").intValue, GUILayout.Width(60)), 1);
 
 
         //Summary of types in this pool
@@ -402,8 +408,13 @@ public class KMMissionEditor : Editor
         KMComponentPool componentPool = mission.GeneratorSetting.ComponentPools[poolIndex];
         SerializedProperty componentPools = serializedObject.FindProperty("GeneratorSetting.ComponentPools");
 
-        var element = componentPools.GetArrayElementAtIndex(poolIndex);
-        EditorGUILayout.PropertyField(element.FindPropertyRelative("ModTypes"), true);
+        var modTypesElement = componentPools.GetArrayElementAtIndex(poolIndex).FindPropertyRelative("ModTypes");
+        EditorGUILayout.PropertyField(modTypesElement, true);
+
+        // Trim whitespace from mod types
+        for (int i = 0; i < modTypesElement.arraySize; i++) {
+            modTypesElement.GetArrayElementAtIndex(i).stringValue = modTypesElement.GetArrayElementAtIndex(i).stringValue.Trim();
+        }
 
         //Clear any special flags if needed
         if (componentPool.ModTypes != null && componentPool.ModTypes.Count > 0)

--- a/Assets/Editor/Scripts/Missions/KMMissionTableOfContentsEditor.cs
+++ b/Assets/Editor/Scripts/Missions/KMMissionTableOfContentsEditor.cs
@@ -47,19 +47,15 @@ public class KMMissionTableOfContentsEditor : Editor
         AssetImporter.GetAtPath(path).assetBundleName = AssetBundler.BUNDLE_FILENAME;
 
         EditorGUIUtility.PingObject(tableOfContents);
-
-        int numToCs = AssetDatabase.FindAssets("t:KMMissionTableOfContents").Length;
-        if (numToCs > 1)
-        {
-            Debug.LogWarningFormat("Project has {0} KMMissionTableOfContents. Only one table of contents per mod is supported!", numToCs);
-        }
     }
 
     public override void OnInspectorGUI()
     {
         serializedObject.Update();
 
-        EditorGUILayout.PropertyField(serializedObject.FindProperty("Title"));
+        var titleProperty = serializedObject.FindProperty("Title");
+        EditorGUILayout.PropertyField(titleProperty);
+        titleProperty.stringValue = titleProperty.stringValue.Trim();
 
         DrawTableOfContentsToolbar();
         DrawTableOfContents();
@@ -170,7 +166,7 @@ public class KMMissionTableOfContentsEditor : Editor
         EditorGUILayout.LabelField(string.Format("{0}.", sectionIndex + 1), GUILayout.Width(30));
 
         SerializedProperty titleProperty = sectionProperty.FindPropertyRelative("Title");
-        titleProperty.stringValue = EditorGUILayout.TextField(titleProperty.stringValue);
+        titleProperty.stringValue = EditorGUILayout.TextField(titleProperty.stringValue).Trim();
 
         GUILayout.FlexibleSpace();
 

--- a/Assets/Editor/Scripts/ModConfig.cs
+++ b/Assets/Editor/Scripts/ModConfig.cs
@@ -20,6 +20,12 @@ public sealed class ModConfig : ScriptableObject
         set { Instance.title = value; }
     }
 
+    public static string Author
+    {
+        get { return Instance.title; }
+        set { Instance.title = value; }
+    }
+
     public static string Description
     {
         get { return Instance.description; }
@@ -49,6 +55,8 @@ public sealed class ModConfig : ScriptableObject
     [SerializeField]
     private string title = "";
     [SerializeField]
+    private string author = "";
+    [SerializeField]
     [TextArea(5, 10)]
     private string description = "";
     [SerializeField]
@@ -67,6 +75,10 @@ public sealed class ModConfig : ScriptableObject
             if (instance == null)
             {
                 instance = Resources.Load<ModConfig>("ModConfig");
+                if (instance == null)
+                {
+                    ModKitSettingsEditor.CreateModConfig(out instance);
+                }
             }
             return instance;
         }
@@ -82,6 +94,7 @@ public sealed class ModConfig : ScriptableObject
         Dictionary<string, object> dict = new Dictionary<string, object>();
         dict.Add("id", id);
         dict.Add("title", title);
+        dict.Add("author", author);
         dict.Add("description", description);
         dict.Add("version", version);
         dict.Add("unityVersion", Application.unityVersion);

--- a/Assets/Editor/Scripts/ModKitSettingsEditor.cs
+++ b/Assets/Editor/Scripts/ModKitSettingsEditor.cs
@@ -15,64 +15,50 @@ public class ModKitSettingsEditor : Editor
         var modConfig = ModConfig.Instance;
         if (modConfig == null)
         {
-            modConfig = ScriptableObject.CreateInstance<ModConfig>();
-            string properPath = Path.Combine(Path.Combine(Application.dataPath, "Editor"), "Resources");
-            if (!Directory.Exists(properPath))
-            {
-                AssetDatabase.CreateFolder("Assets/Editor", "Resources");
-            }
-
-            string fullPath = Path.Combine(
-                Path.Combine("Assets", "Editor"),
-                Path.Combine("Resources", "ModConfig.asset")
-            );
-            AssetDatabase.CreateAsset(modConfig, fullPath);
-            ModConfig.Instance = modConfig;
+            CreateModConfig(out modConfig);
         }
         UnityEditor.Selection.activeObject = modConfig;
     }
 
+    public static void CreateModConfig(out ModConfig modConfig)
+    {
+        modConfig = ScriptableObject.CreateInstance<ModConfig>();
+        string properPath = Path.Combine(Path.Combine(Application.dataPath, "Editor"), "Resources");
+        if (!Directory.Exists(properPath))
+        {
+            AssetDatabase.CreateFolder("Assets/Editor", "Resources");
+        }
+
+        string fullPath = Path.Combine(
+            Path.Combine("Assets", "Editor"),
+            Path.Combine("Resources", "ModConfig.asset")
+        );
+        AssetDatabase.CreateAsset(modConfig, fullPath);
+        ModConfig.Instance = modConfig;
+    }
+
     public override void OnInspectorGUI()
     {
-        EditorGUILayout.Separator();
-        EditorGUILayout.BeginHorizontal();
-        
-        GUIContent idLabel = new GUIContent("Mod ID", "Identifier for the mod. Affects assembly name and output name.");
-        GUI.changed = false;
-        ModConfig.ID = EditorGUILayout.TextField(idLabel, ModConfig.ID);
-        SetDirtyOnGUIChange();
-        EditorGUILayout.EndHorizontal();
+        //Basic Info
+        EditorGUILayout.BeginVertical(EditorStyles.helpBox);
 
-        EditorGUILayout.Separator();
-        EditorGUILayout.BeginHorizontal();
-        GUIContent titleLabel = new GUIContent("Mod Title", "Name of the mod as it appears in game.");
-        GUI.changed = false;
-        ModConfig.Title = EditorGUILayout.TextField(titleLabel, ModConfig.Title);
-        SetDirtyOnGUIChange();
-        EditorGUILayout.EndHorizontal();
+        var idProperty = serializedObject.FindProperty("id");
+        EditorGUILayout.PropertyField(idProperty);
+        idProperty.stringValue = idProperty.stringValue.Trim();
 
-        EditorGUILayout.BeginHorizontal();
-        EditorGUILayout.Separator();
+        var titleProperty = serializedObject.FindProperty("title");
+        EditorGUILayout.PropertyField(titleProperty);
+        titleProperty.stringValue = titleProperty.stringValue.Trim();
+
+        var authorProperty = serializedObject.FindProperty("author");
+        EditorGUILayout.PropertyField(authorProperty, new GUIContent("Author", "Only shown in local mods, mods from Steam will show Steam user as author"));
+        authorProperty.stringValue = authorProperty.stringValue.Trim();
+
         EditorGUILayout.PropertyField(serializedObject.FindProperty("description"));
-        SetDirtyOnGUIChange();
-        EditorGUILayout.EndHorizontal();
+        EditorGUILayout.PropertyField(serializedObject.FindProperty("version"));
+        EditorGUILayout.PropertyField(serializedObject.FindProperty("outputFolder"));
 
-        EditorGUILayout.Separator();
-        EditorGUILayout.BeginHorizontal();
-        GUIContent versionLabel = new GUIContent("Mod Version", "Current version of the mod.");
-        GUI.changed = false;
-        ModConfig.Version = EditorGUILayout.TextField(versionLabel, ModConfig.Version);
-        SetDirtyOnGUIChange();
-        EditorGUILayout.EndHorizontal();
-
-        EditorGUILayout.Separator();
-        EditorGUILayout.BeginHorizontal();
-        GUIContent outputFolderLabel = new GUIContent("Mod Output Folder", "Folder relative to the project where the built mod bundle will be placed.");
-        GUI.changed = false;
-        ModConfig.OutputFolder = EditorGUILayout.TextField(outputFolderLabel, ModConfig.OutputFolder);
-        SetDirtyOnGUIChange();
-        EditorGUILayout.EndHorizontal();
-        EditorGUILayout.HelpBox("This folder will be cleaned with each build.", MessageType.Warning);
+        EditorGUILayout.EndVertical();
 
         //Preview Image
         EditorGUILayout.BeginHorizontal(EditorStyles.helpBox);
@@ -97,17 +83,6 @@ public class ModKitSettingsEditor : Editor
         }
         GUILayout.Label(ModConfig.PreviewImage, GUILayout.MaxWidth(128), GUILayout.MaxHeight(128));
         EditorGUILayout.EndHorizontal();
-
         serializedObject.ApplyModifiedProperties();
-        GUI.enabled = true;
-    }
-
-    private void SetDirtyOnGUIChange()
-    {
-        if (GUI.changed)
-        {
-            EditorUtility.SetDirty(ModConfig.Instance);
-            GUI.changed = false;
-        }
     }
 }

--- a/Assets/Editor/Scripts/Workshop/WorkshopEditorWindow.cs
+++ b/Assets/Editor/Scripts/Workshop/WorkshopEditorWindow.cs
@@ -3,6 +3,7 @@ using Steamworks;
 using UnityEngine;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Collections.Generic;
 
 public class WorkshopEditorWindow : EditorWindow
@@ -96,13 +97,15 @@ public class WorkshopEditorWindow : EditorWindow
             GUI.backgroundColor = new Color(0.1f, 0.1f, 0.5f, 0.7f);
             EditorGUILayout.BeginVertical(EditorStyles.helpBox);
             GUI.backgroundColor = oldBGColor;
+            
+            string folder = GetContentPath();
 
             EditorGUILayout.LabelField("Publishing Tools", EditorStyles.largeLabel);
             EditorGUILayout.Separator();
             EditorGUILayout.LabelField("User:", userName);
-            EditorGUILayout.LabelField("Content Folder:", GetContentPath());
+            EditorGUILayout.LabelField("Content Folder:", folder);
 
-            DirectoryInfo dir = new DirectoryInfo(GetContentPath());
+            DirectoryInfo dir = new DirectoryInfo(folder);
 
             if (dir.Exists)
             {
@@ -139,6 +142,11 @@ public class WorkshopEditorWindow : EditorWindow
             {
                 EditorGUILayout.HelpBox("Change notes must be entered before publishing to Workshop", MessageType.Warning);
             }
+            
+            if(dir.GetFiles("modInfo_Harmony.json").Length > 0)
+			{
+				EditorGUILayout.HelpBox("Your mod uses the Harmony library. This means it won't work without the Harmony mod, so on the Workshop, please either add the Harmony mod as a dependency or mention it in the description!", MessageType.Warning);
+			}
 
 
             //Publishing changes
@@ -162,7 +170,7 @@ public class WorkshopEditorWindow : EditorWindow
                 {
                     PublishWorkshopChanges();
                 }
-
+				
                 if (!string.IsNullOrEmpty(ugcUpdateStatus))
                 {
                     EditorGUILayout.LabelField(ugcUpdateStatus);
@@ -170,6 +178,7 @@ public class WorkshopEditorWindow : EditorWindow
 
                 GUI.enabled = true;
             }
+            
             EditorGUILayout.EndVertical();
             EditorGUILayout.EndScrollView();
         }
@@ -326,6 +335,8 @@ public class WorkshopEditorWindow : EditorWindow
         if (result.m_eResult == EResult.k_EResultOK)
         {
             currentWorkshopItem.WorkshopPublishedFileID = result.m_nPublishedFileId.m_PublishedFileId;
+            AssetDatabase.SaveAssets();
+
             PublishWorkshopChanges();
         }
     }

--- a/Assets/Plugins/Editor.meta
+++ b/Assets/Plugins/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e8276801f2d349a192a240512734758
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/ModSelectorTablet.prefab
+++ b/Assets/Prefabs/ModSelectorTablet.prefab
@@ -460,6 +460,7 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -479,6 +480,7 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
@@ -496,6 +498,7 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -511,6 +514,7 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
@@ -528,6 +532,7 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -543,6 +548,7 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
@@ -560,6 +566,7 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -575,6 +582,7 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
@@ -592,6 +600,7 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -607,6 +616,7 @@ MeshRenderer:
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
@@ -624,6 +634,7 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -639,6 +650,7 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
@@ -656,6 +668,7 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -671,6 +684,7 @@ MeshRenderer:
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
@@ -877,7 +891,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   targetPosition: {x: 0.25, y: 1.3, z: -1.52}
   targetRotation: {x: 13.5, y: 0, z: 0}
-  HoldableAvailability: 0
+  HoldableAvailability: 2
 --- !u!114 &114067708825517960
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/ModSelectorService.cs
+++ b/Assets/Scripts/ModSelectorService.cs
@@ -326,6 +326,7 @@ public class ModSelectorService : MonoBehaviour
         _properties.Add("AddPageMethod", () => (Action<KMSelectable>)PageManager.AddPagePrefab, null);
         _properties.Add("AddPagesMethod", () => (Action<KMSelectable[]>)PageManager.AddPagePrefabs, null);
         _properties.Add("AddHomePageMethod", () => (Action<string, KMSelectable, Texture2D>)PageManager.AddHomePageEntry, null);
+        _properties.Add("AddRoomHomePageMethod", () => (Action<string, KMSelectable, Texture2D, KMHoldable.HoldableAvailabilityEnum>)PageManager.AddRoomHomePageEntry, null);
         _properties.Add("GoToPageMethod", () => (Action<string>)FindObjectOfType<PageNavigation>().GoToPage, null);
         _properties.Add("GoBackMethod", () => (Action)FindObjectOfType<PageNavigation>().GoBack, null);
 
@@ -380,6 +381,7 @@ public class ModSelectorService : MonoBehaviour
     #region Setup
     private void OnStateChange(KMGameInfo.State state)
     {
+        PageManager.CurrentState = state;
         if (_updateRequired && state == KMGameInfo.State.Setup)
         {
             //Update the mod info

--- a/Assets/Scripts/ModSelectorTablet.cs
+++ b/Assets/Scripts/ModSelectorTablet.cs
@@ -1,6 +1,53 @@
-﻿using UnityEngine;
+﻿using System.Collections;
+using System.Reflection;
+using UnityEngine;
 
 public class ModSelectorTablet : MonoBehaviour
 {
+    public static ModSelectorTablet Instance;
 
+    private const BindingFlags ReflectionFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+    private static readonly FieldInfo HoldableTargetField;
+    private static readonly FieldInfo HoldableTargetInitializedField;
+    private static readonly MethodInfo HoldableTargetStartMethod;
+
+    private readonly Vector3 SetupPosition = new Vector3(.25f, 1.3f, -1.52f);
+    private readonly Vector3 GameplayPosition = new Vector3(.09f, 1.225f, -1.41f);
+    
+    private readonly Vector3 SetupRotation = new Vector3(13.5f, 0f, 0f);
+    private readonly Vector3 GameplayRotation = new Vector3(8f, 0f, 0f);
+    
+    private void Awake()
+    {
+        Instance = this;
+    }
+
+#if !UNITY_EDITOR
+    private IEnumerator Start()
+    {
+        yield return new WaitUntil(() => PageManager.CurrentState != KMGameInfo.State.Transitioning);
+        var holdable_target = (MonoBehaviour)HoldableTargetField.GetValue(GetComponent("FloatingHoldable"));
+        if(PageManager.CurrentState == KMGameInfo.State.Setup)
+        {
+            holdable_target.transform.position = SetupPosition;
+            holdable_target.transform.rotation = Quaternion.Euler(SetupRotation);
+        }
+        else
+        {
+            holdable_target.transform.position = GameplayPosition;
+            holdable_target.transform.rotation = Quaternion.Euler(GameplayRotation);
+        }
+        HoldableTargetInitializedField.SetValue(holdable_target, false);
+        HoldableTargetStartMethod.Invoke(holdable_target, new object[0]);
+    }
+
+    static ModSelectorTablet()
+    {
+        HoldableTargetField = ReflectionHelper.FindTypeInGame("FloatingHoldable").GetField("HoldableTarget", ReflectionFlags);
+        var HoldableTargetType = HoldableTargetField.FieldType;
+        HoldableTargetStartMethod = HoldableTargetType.GetMethod("Start", ReflectionFlags);
+        HoldableTargetInitializedField =
+            HoldableTargetType.GetField("isInitialized", ReflectionFlags);
+    }
+#endif
 }

--- a/Assets/Scripts/Pages/HomePage.cs
+++ b/Assets/Scripts/Pages/HomePage.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections;
+using System.Linq;
 using UnityEngine;
 
 public class HomePage : MonoBehaviour
@@ -16,7 +17,14 @@ public class HomePage : MonoBehaviour
 
     private void OnEnable()
     {
-        _homePageEntries = PageManager.HomePageEntries.ToArray();
+        StartCoroutine(DisplayPages());
+    }
+    
+    private IEnumerator DisplayPages()
+    {
+        yield return new WaitUntil(() => PageManager.CurrentState != KMGameInfo.State.Transitioning);
+        
+        _homePageEntries = PageManager.HomePageEntries.Where(page => page.Enabled).ToArray();
 
         for (int pageLinkIndex = 0; pageLinkIndex < _pageLinks.Length; ++pageLinkIndex)
         {
@@ -37,5 +45,8 @@ public class HomePage : MonoBehaviour
             element.Icon = homePageEntry.Icon;
             pageLink.PagePrefab = homePageEntry.PageSelectable;
         }
+
+        if(_homePageEntries.Length == 0)
+            Destroy(ModSelectorTablet.Instance.gameObject);
     }
 }

--- a/Assets/Scripts/Pages/PageManager.cs
+++ b/Assets/Scripts/Pages/PageManager.cs
@@ -8,7 +8,22 @@ public class PageManager : MonoBehaviour
         public string DisplayName;
         public KMSelectable PageSelectable;
         public Texture2D Icon;
+        public KMHoldable.HoldableAvailabilityEnum Availability;
+
+        public bool Enabled
+        {
+            get
+            {
+                return Availability == KMHoldable.HoldableAvailabilityEnum.ALL ||
+                       Availability == KMHoldable.HoldableAvailabilityEnum.SETUP &&
+                       CurrentState == KMGameInfo.State.Setup ||
+                       Availability == KMHoldable.HoldableAvailabilityEnum.GAMEPLAY &&
+                       CurrentState == KMGameInfo.State.Gameplay;
+            }
+        }
     }
+
+    public static KMGameInfo.State CurrentState = KMGameInfo.State.Setup;
 
     public Transform RootTransform = null;
 
@@ -76,7 +91,12 @@ public class PageManager : MonoBehaviour
 
     public static void AddHomePageEntry(string displayName, KMSelectable pageSelectable, Texture2D icon)
     {
-        HomePageEntryList.Add(new HomePageEntry() { DisplayName = displayName, PageSelectable = pageSelectable, Icon = icon });
+        HomePageEntryList.Add(new HomePageEntry() { DisplayName = displayName, PageSelectable = pageSelectable, Icon = icon, Availability = KMHoldable.HoldableAvailabilityEnum.SETUP});
+    }
+
+    public static void AddRoomHomePageEntry(string displayName, KMSelectable pageSelectable, Texture2D icon, KMHoldable.HoldableAvailabilityEnum availability)
+    {
+        HomePageEntryList.Add(new HomePageEntry() { DisplayName = displayName, PageSelectable = pageSelectable, Icon = icon, Availability = availability});
     }
 
     public void DestroyCachedPages()

--- a/ProjectSettings/EditorSettings.asset
+++ b/ProjectSettings/EditorSettings.asset
@@ -3,13 +3,19 @@
 --- !u!159 &1
 EditorSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 3
+  serializedVersion: 7
   m_ExternalVersionControlSupport: Hidden Meta Files
   m_SerializationMode: 2
-  m_WebSecurityEmulationEnabled: 0
-  m_WebSecurityEmulationHostUrl: http://www.mydomain.com/mygame.unity3d
+  m_LineEndingsForNewScripts: 1
   m_DefaultBehaviorMode: 0
   m_SpritePackerMode: 2
   m_SpritePackerPaddingPower: 1
-  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd
+  m_EtcTextureCompressorBehavior: 0
+  m_EtcTextureFastCompressor: 2
+  m_EtcTextureNormalCompressor: 2
+  m_EtcTextureBestCompressor: 5
+  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef
   m_ProjectGenerationRootNamespace: 
+  m_UserGeneratedProjectSuffix: 
+  m_CollabEditorSettings:
+    inProgressEnabled: 1


### PR DESCRIPTION
ModSelector is an awesome framework for creating custom holdables and is being used by more and more mods. I thought it'd be nice to make it available in the gameplay room and allow the API to create pages specific to that room (or both).

So I've made the ModSelector tablet also appear in the gameplay room and added an API property (`AddRoomHomePageMethod`) that works like the old (`AddHomePageMethod`) property, but it also takes a `KMHoldable.HoldableAvailabilityEnum` argument (which can be `SETUP`, `GAMEPLAY`, `ALL` or `NONE`) which denotes which room the page should be available in. If there aren't any pages available in the gameplay room, the tablet will be destroyed on spawn.

I've also updated the AssetBundler because the old one didn't work properly on Linux.